### PR TITLE
concatenate string instead of formatting to play nice with proxy

### DIFF
--- a/src/data/websocketStore.ts
+++ b/src/data/websocketStore.ts
@@ -6,7 +6,7 @@ const url: string =
 	typeof window !== 'undefined'
 		? `ws${window.location.protocol === 'https:' ? 's' : ''}://${
 				window.location.host
-		  }/management/ws`
+		  }` + "/management/ws"
 		: 'ws://localhost:8080/ws';
 
 // Create the WebSocket store using the provided function


### PR DESCRIPTION
Proxy substitutes url paths in quotes, but misses this path which breaks the page's websockets. Slight change to concatenate the url path on instead of including it in the format string.