### PR TITLE
Restores "advanced values" input in the Install page

### DIFF
--- a/backend/types/marketplace.go
+++ b/backend/types/marketplace.go
@@ -1,9 +1,12 @@
 package types
 
+type AdvancedValue map[string]interface{}
+
 type ApplicationInstallParams struct {
 	Name           string
 	Version        string
-	DisplayName string
+	DisplayName    string
 	DeploymentName string
 	Variables      map[string]string
+	AdvancedValues AdvancedValue
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -919,6 +919,267 @@
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
 			}
 		},
+		"node_modules/@parcel/watcher": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.4.1.tgz",
+			"integrity": "sha512-HNjmfLQEVRZmHRET336f20H/8kOozUGwk7yajvsonjNxbj2wBTK1WsQuHkD5yYh9RxFGL2EyDHryOihOwUoKDA==",
+			"devOptional": true,
+			"dependencies": {
+				"detect-libc": "^1.0.3",
+				"is-glob": "^4.0.3",
+				"micromatch": "^4.0.5",
+				"node-addon-api": "^7.0.0"
+			},
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			},
+			"optionalDependencies": {
+				"@parcel/watcher-android-arm64": "2.4.1",
+				"@parcel/watcher-darwin-arm64": "2.4.1",
+				"@parcel/watcher-darwin-x64": "2.4.1",
+				"@parcel/watcher-freebsd-x64": "2.4.1",
+				"@parcel/watcher-linux-arm-glibc": "2.4.1",
+				"@parcel/watcher-linux-arm64-glibc": "2.4.1",
+				"@parcel/watcher-linux-arm64-musl": "2.4.1",
+				"@parcel/watcher-linux-x64-glibc": "2.4.1",
+				"@parcel/watcher-linux-x64-musl": "2.4.1",
+				"@parcel/watcher-win32-arm64": "2.4.1",
+				"@parcel/watcher-win32-ia32": "2.4.1",
+				"@parcel/watcher-win32-x64": "2.4.1"
+			}
+		},
+		"node_modules/@parcel/watcher-android-arm64": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.4.1.tgz",
+			"integrity": "sha512-LOi/WTbbh3aTn2RYddrO8pnapixAziFl6SMxHM69r3tvdSm94JtCenaKgk1GRg5FJ5wpMCpHeW+7yqPlvZv7kg==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-darwin-arm64": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.4.1.tgz",
+			"integrity": "sha512-ln41eihm5YXIY043vBrrHfn94SIBlqOWmoROhsMVTSXGh0QahKGy77tfEywQ7v3NywyxBBkGIfrWRHm0hsKtzA==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-darwin-x64": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.4.1.tgz",
+			"integrity": "sha512-yrw81BRLjjtHyDu7J61oPuSoeYWR3lDElcPGJyOvIXmor6DEo7/G2u1o7I38cwlcoBHQFULqF6nesIX3tsEXMg==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-freebsd-x64": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.4.1.tgz",
+			"integrity": "sha512-TJa3Pex/gX3CWIx/Co8k+ykNdDCLx+TuZj3f3h7eOjgpdKM+Mnix37RYsYU4LHhiYJz3DK5nFCCra81p6g050w==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-linux-arm-glibc": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.4.1.tgz",
+			"integrity": "sha512-4rVYDlsMEYfa537BRXxJ5UF4ddNwnr2/1O4MHM5PjI9cvV2qymvhwZSFgXqbS8YoTk5i/JR0L0JDs69BUn45YA==",
+			"cpu": [
+				"arm"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-linux-arm64-glibc": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.4.1.tgz",
+			"integrity": "sha512-BJ7mH985OADVLpbrzCLgrJ3TOpiZggE9FMblfO65PlOCdG++xJpKUJ0Aol74ZUIYfb8WsRlUdgrZxKkz3zXWYA==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-linux-arm64-musl": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.4.1.tgz",
+			"integrity": "sha512-p4Xb7JGq3MLgAfYhslU2SjoV9G0kI0Xry0kuxeG/41UfpjHGOhv7UoUDAz/jb1u2elbhazy4rRBL8PegPJFBhA==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-linux-x64-glibc": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.4.1.tgz",
+			"integrity": "sha512-s9O3fByZ/2pyYDPoLM6zt92yu6P4E39a03zvO0qCHOTjxmt3GHRMLuRZEWhWLASTMSrrnVNWdVI/+pUElJBBBg==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-linux-x64-musl": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.4.1.tgz",
+			"integrity": "sha512-L2nZTYR1myLNST0O632g0Dx9LyMNHrn6TOt76sYxWLdff3cB22/GZX2UPtJnaqQPdCRoszoY5rcOj4oMTtp5fQ==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-win32-arm64": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.4.1.tgz",
+			"integrity": "sha512-Uq2BPp5GWhrq/lcuItCHoqxjULU1QYEcyjSO5jqqOK8RNFDBQnenMMx4gAl3v8GiWa59E9+uDM7yZ6LxwUIfRg==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-win32-ia32": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.4.1.tgz",
+			"integrity": "sha512-maNRit5QQV2kgHFSYwftmPBxiuK5u4DXjbXx7q6eKjq5dsLXZ4FJiVvlcw35QXzk0KrUecJmuVFbj4uV9oYrcw==",
+			"cpu": [
+				"ia32"
+			],
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-win32-x64": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.4.1.tgz",
+			"integrity": "sha512-+DvS92F9ezicfswqrvIRM2njcYJbd5mb9CUgtrHCHmvn7pPPa+nMDRu1o1bYYz/l5IB2NVGNJWiH7h1E58IF2A==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
 		"node_modules/@pkgjs/parseargs": {
 			"version": "0.11.0",
 			"resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -4913,6 +5174,12 @@
 				"node": ">= 0.6"
 			}
 		},
+		"node_modules/node-addon-api": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+			"integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+			"devOptional": true
+		},
 		"node_modules/node-gyp": {
 			"version": "9.3.1",
 			"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-9.3.1.tgz",
@@ -6797,12 +7064,13 @@
 			}
 		},
 		"node_modules/sass": {
-			"version": "1.62.1",
-			"resolved": "https://registry.npmjs.org/sass/-/sass-1.62.1.tgz",
-			"integrity": "sha512-NHpxIzN29MXvWiuswfc1W3I0N8SXBd8UR26WntmDlRYf0bSADnwnOjsyMZ3lMezSlArD33Vs3YFhp7dWvL770A==",
+			"version": "1.80.4",
+			"resolved": "https://registry.npmjs.org/sass/-/sass-1.80.4.tgz",
+			"integrity": "sha512-rhMQ2tSF5CsuuspvC94nPM9rToiAFw2h3JTrLlgmNw1MH79v8Cr3DH6KF6o6r+8oofY3iYVPUf66KzC8yuVN1w==",
 			"devOptional": true,
 			"dependencies": {
-				"chokidar": ">=3.0.0 <4.0.0",
+				"@parcel/watcher": "^2.4.1",
+				"chokidar": "^4.0.0",
 				"immutable": "^4.0.0",
 				"source-map-js": ">=0.6.2 <2.0.0"
 			},
@@ -6811,6 +7079,34 @@
 			},
 			"engines": {
 				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/sass/node_modules/chokidar": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.1.tgz",
+			"integrity": "sha512-n8enUVCED/KVRQlab1hr3MVpcVMvxtZjmEa956u+4YijlmQED223XMSYj2tLuKvr4jcCTzNNMpQDUer72MMmzA==",
+			"devOptional": true,
+			"dependencies": {
+				"readdirp": "^4.0.1"
+			},
+			"engines": {
+				"node": ">= 14.16.0"
+			},
+			"funding": {
+				"url": "https://paulmillr.com/funding/"
+			}
+		},
+		"node_modules/sass/node_modules/readdirp": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.0.2.tgz",
+			"integrity": "sha512-yDMz9g+VaZkqBYS/ozoBJwaBhTbZo3UNYQHNRw1D3UFQB8oHB4uS/tAODO+ZLjGWmUbKnIlOWO+aaIiAxrUWHA==",
+			"devOptional": true,
+			"engines": {
+				"node": ">= 14.16.0"
+			},
+			"funding": {
+				"type": "individual",
+				"url": "https://paulmillr.com/funding/"
 			}
 		},
 		"node_modules/semver": {
@@ -8953,6 +9249,102 @@
 					}
 				}
 			}
+		},
+		"@parcel/watcher": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.4.1.tgz",
+			"integrity": "sha512-HNjmfLQEVRZmHRET336f20H/8kOozUGwk7yajvsonjNxbj2wBTK1WsQuHkD5yYh9RxFGL2EyDHryOihOwUoKDA==",
+			"devOptional": true,
+			"requires": {
+				"@parcel/watcher-android-arm64": "2.4.1",
+				"@parcel/watcher-darwin-arm64": "2.4.1",
+				"@parcel/watcher-darwin-x64": "2.4.1",
+				"@parcel/watcher-freebsd-x64": "2.4.1",
+				"@parcel/watcher-linux-arm-glibc": "2.4.1",
+				"@parcel/watcher-linux-arm64-glibc": "2.4.1",
+				"@parcel/watcher-linux-arm64-musl": "2.4.1",
+				"@parcel/watcher-linux-x64-glibc": "2.4.1",
+				"@parcel/watcher-linux-x64-musl": "2.4.1",
+				"@parcel/watcher-win32-arm64": "2.4.1",
+				"@parcel/watcher-win32-ia32": "2.4.1",
+				"@parcel/watcher-win32-x64": "2.4.1",
+				"detect-libc": "^1.0.3",
+				"is-glob": "^4.0.3",
+				"micromatch": "^4.0.5",
+				"node-addon-api": "^7.0.0"
+			}
+		},
+		"@parcel/watcher-android-arm64": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.4.1.tgz",
+			"integrity": "sha512-LOi/WTbbh3aTn2RYddrO8pnapixAziFl6SMxHM69r3tvdSm94JtCenaKgk1GRg5FJ5wpMCpHeW+7yqPlvZv7kg==",
+			"optional": true
+		},
+		"@parcel/watcher-darwin-arm64": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.4.1.tgz",
+			"integrity": "sha512-ln41eihm5YXIY043vBrrHfn94SIBlqOWmoROhsMVTSXGh0QahKGy77tfEywQ7v3NywyxBBkGIfrWRHm0hsKtzA==",
+			"optional": true
+		},
+		"@parcel/watcher-darwin-x64": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.4.1.tgz",
+			"integrity": "sha512-yrw81BRLjjtHyDu7J61oPuSoeYWR3lDElcPGJyOvIXmor6DEo7/G2u1o7I38cwlcoBHQFULqF6nesIX3tsEXMg==",
+			"optional": true
+		},
+		"@parcel/watcher-freebsd-x64": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.4.1.tgz",
+			"integrity": "sha512-TJa3Pex/gX3CWIx/Co8k+ykNdDCLx+TuZj3f3h7eOjgpdKM+Mnix37RYsYU4LHhiYJz3DK5nFCCra81p6g050w==",
+			"optional": true
+		},
+		"@parcel/watcher-linux-arm-glibc": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.4.1.tgz",
+			"integrity": "sha512-4rVYDlsMEYfa537BRXxJ5UF4ddNwnr2/1O4MHM5PjI9cvV2qymvhwZSFgXqbS8YoTk5i/JR0L0JDs69BUn45YA==",
+			"optional": true
+		},
+		"@parcel/watcher-linux-arm64-glibc": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.4.1.tgz",
+			"integrity": "sha512-BJ7mH985OADVLpbrzCLgrJ3TOpiZggE9FMblfO65PlOCdG++xJpKUJ0Aol74ZUIYfb8WsRlUdgrZxKkz3zXWYA==",
+			"optional": true
+		},
+		"@parcel/watcher-linux-arm64-musl": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.4.1.tgz",
+			"integrity": "sha512-p4Xb7JGq3MLgAfYhslU2SjoV9G0kI0Xry0kuxeG/41UfpjHGOhv7UoUDAz/jb1u2elbhazy4rRBL8PegPJFBhA==",
+			"optional": true
+		},
+		"@parcel/watcher-linux-x64-glibc": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.4.1.tgz",
+			"integrity": "sha512-s9O3fByZ/2pyYDPoLM6zt92yu6P4E39a03zvO0qCHOTjxmt3GHRMLuRZEWhWLASTMSrrnVNWdVI/+pUElJBBBg==",
+			"optional": true
+		},
+		"@parcel/watcher-linux-x64-musl": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.4.1.tgz",
+			"integrity": "sha512-L2nZTYR1myLNST0O632g0Dx9LyMNHrn6TOt76sYxWLdff3cB22/GZX2UPtJnaqQPdCRoszoY5rcOj4oMTtp5fQ==",
+			"optional": true
+		},
+		"@parcel/watcher-win32-arm64": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.4.1.tgz",
+			"integrity": "sha512-Uq2BPp5GWhrq/lcuItCHoqxjULU1QYEcyjSO5jqqOK8RNFDBQnenMMx4gAl3v8GiWa59E9+uDM7yZ6LxwUIfRg==",
+			"optional": true
+		},
+		"@parcel/watcher-win32-ia32": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.4.1.tgz",
+			"integrity": "sha512-maNRit5QQV2kgHFSYwftmPBxiuK5u4DXjbXx7q6eKjq5dsLXZ4FJiVvlcw35QXzk0KrUecJmuVFbj4uV9oYrcw==",
+			"optional": true
+		},
+		"@parcel/watcher-win32-x64": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.4.1.tgz",
+			"integrity": "sha512-+DvS92F9ezicfswqrvIRM2njcYJbd5mb9CUgtrHCHmvn7pPPa+nMDRu1o1bYYz/l5IB2NVGNJWiH7h1E58IF2A==",
+			"optional": true
 		},
 		"@pkgjs/parseargs": {
 			"version": "0.11.0",
@@ -11819,6 +12211,12 @@
 			"integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
 			"dev": true
 		},
+		"node-addon-api": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+			"integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+			"devOptional": true
+		},
 		"node-gyp": {
 			"version": "9.3.1",
 			"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-9.3.1.tgz",
@@ -13111,14 +13509,32 @@
 			}
 		},
 		"sass": {
-			"version": "1.62.1",
-			"resolved": "https://registry.npmjs.org/sass/-/sass-1.62.1.tgz",
-			"integrity": "sha512-NHpxIzN29MXvWiuswfc1W3I0N8SXBd8UR26WntmDlRYf0bSADnwnOjsyMZ3lMezSlArD33Vs3YFhp7dWvL770A==",
+			"version": "1.80.4",
+			"resolved": "https://registry.npmjs.org/sass/-/sass-1.80.4.tgz",
+			"integrity": "sha512-rhMQ2tSF5CsuuspvC94nPM9rToiAFw2h3JTrLlgmNw1MH79v8Cr3DH6KF6o6r+8oofY3iYVPUf66KzC8yuVN1w==",
 			"devOptional": true,
 			"requires": {
-				"chokidar": ">=3.0.0 <4.0.0",
+				"@parcel/watcher": "^2.4.1",
+				"chokidar": "^4.0.0",
 				"immutable": "^4.0.0",
 				"source-map-js": ">=0.6.2 <2.0.0"
+			},
+			"dependencies": {
+				"chokidar": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.1.tgz",
+					"integrity": "sha512-n8enUVCED/KVRQlab1hr3MVpcVMvxtZjmEa956u+4YijlmQED223XMSYj2tLuKvr4jcCTzNNMpQDUer72MMmzA==",
+					"devOptional": true,
+					"requires": {
+						"readdirp": "^4.0.1"
+					}
+				},
+				"readdirp": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.0.2.tgz",
+					"integrity": "sha512-yDMz9g+VaZkqBYS/ozoBJwaBhTbZo3UNYQHNRw1D3UFQB8oHB4uS/tAODO+ZLjGWmUbKnIlOWO+aaIiAxrUWHA==",
+					"devOptional": true
+				}
 			}
 		},
 		"semver": {

--- a/src/routes/install/+page.svelte
+++ b/src/routes/install/+page.svelte
@@ -4,6 +4,7 @@
   import type { NodeGroupType } from '../../data/entities';
   import { productInstall } from '../../store/stores';
   import SetupWizard from '../../components/SetupWizard.svelte';
+  import AdvancedVar from './advanced_var.svelte';
 
   type StartApplicationInstallResponse = {
     deploymentID: string;
@@ -42,6 +43,7 @@
   }
 
   $: Variables = product?.DefaultDeployment?.Variables?.Values || {};
+  $: AdvancedValues = product?.DefaultDeployment?.Variables?.AdvancedValues || {};
   $: {
     Object.entries(Variables).forEach(([key, value]) => {
       if (value) {
@@ -76,7 +78,12 @@
   }
 
   async function installApplication() {
-    const outObj = { Name: product.Name, Version: product.Version, ...applicationMetadata };
+    const outObj = {
+      Name: product.Name,
+      Version: product.Version,
+      AdvancedValues,
+      ...applicationMetadata
+    };
     installInProgress = true;
     const url = '../api/install_application';
     const res = await fetch(url, { method: 'POST', body: JSON.stringify(outObj) });
@@ -152,6 +159,12 @@
           </div>
         {/each}
       </div>
+      {#if AdvancedValues}
+        <hr style="margin-top:10px" />
+        <div class="variablesForm">
+          <AdvancedVar bind:json={AdvancedValues} editMode={true} />
+        </div>
+      {/if}
     {:else if steps[currentStepIndex] === 'summary'}
       <div class="st-typography-small-caps">Installation Summary</div>
       <div class="variablesForm">
@@ -168,6 +181,9 @@
               <div class="st-typography-bold">{value}</div>
             </div>
           {/each}
+          {#if AdvancedValues}
+            <AdvancedVar bind:json={AdvancedValues} />
+          {/if}
         </div>
       </div>
     {/if}

--- a/src/routes/install/advanced_var.svelte
+++ b/src/routes/install/advanced_var.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+	import AdvancedVar from './advanced_var.svelte';
+
+	type JsonValue = string | { [key: string]: JsonValue };
+	export let json: { [key: string]: JsonValue };
+	export let indent = 0;
+	export let path: string[] = [];
+	export let editMode: Boolean = false;
+</script>
+
+<div>
+	{#each Object.entries(json) as [key, value]}
+		<div style="padding-left:{indent}px; margin-bottom: 5px;">
+			{#if typeof value === 'object'}
+				<div class="st-typography-label" style="margin-bottom: 5px;">{key}:</div>
+				<AdvancedVar bind:json={value} indent={indent + 10} path={path.concat([key])} {editMode} />
+			{:else}
+				<div style=" display: flex; align-items: center;">
+					<div class="st-typography-label">{key}:&nbsp;</div>
+					{#if editMode}
+						<input class="st-input" style="margin-left: 5px;" bind:value={json[key]} />
+					{:else}
+						<div class="st-typography-bold">{value}</div>
+					{/if}
+				</div>
+			{/if}
+		</div>
+	{/each}
+</div>


### PR DESCRIPTION
This brings back the ability to modify "Advanced Values" in the UI.

Just for reference, the Advanced Values are then put in to the Terraform file that's built in this way:

```  helm_charts = {
    airflow = {
      chart      = "airflow"
      repository = "https://airflow.apache.org"
      version    = "1.13.1"
    }
    keda = {
      chart      = "keda"
      repository = "https://kedacore.github.io/charts"
      version    = "v2.14.2"
    }
  }
```

This appears to be how things were before. Let me know if it needs changing.