### PR TITLE
Propagates some error messages during installation back to the UI

### DIFF
--- a/backend/internal/processes/marketplace.go
+++ b/backend/internal/processes/marketplace.go
@@ -13,30 +13,36 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"errors"
 )
 
 func FetchMarketplaceMetadata(name string, version string, appConfig *config.AppConfig) (marketplace.MarketplaceMetadata, error) {
 
 	log.Infof("Fetching marketplace metadata for, %s, %s", name, version)
 	url := fmt.Sprintf("%sunity-sds/unity-marketplace/main/applications/%s/%s/metadata.json", appConfig.MarketplaceBaseUrl, name, version)
+
+	log.Infof("Fetching marketplace metadata at: %s", url)
 	resp, err := http.Get(url)
 	if err != nil {
 		log.Errorf("Error fetching from github: %v", err)
-		return marketplace.MarketplaceMetadata{}, err
+		errMsg := fmt.Sprintf("Error fetching metadata from url: %s", url)
+		return marketplace.MarketplaceMetadata{}, errors.New(errMsg)
 	}
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		log.Errorf("Error reading file: %v", err)
-		return marketplace.MarketplaceMetadata{}, err
+		errMsg := fmt.Sprintf("Error fetching metadata from url: %s", url)
+		return marketplace.MarketplaceMetadata{}, errors.New(errMsg)
 	}
 
 	content := string(body)
 	req := &marketplace.MarketplaceMetadata{}
 	err = protojson.Unmarshal([]byte(content), req)
 	if err != nil {
-		log.WithError(err).Error("Error unmarshalling file")
+		errMsg := fmt.Sprintf("Error fetching metadata from url: %s", url)
+		return marketplace.MarketplaceMetadata{}, errors.New(errMsg)
 	}
 	return *req, err
 }

--- a/backend/internal/web/api.go
+++ b/backend/internal/web/api.go
@@ -96,7 +96,8 @@ func handleApplicationInstall(appConfig config.AppConfig, db database.Datastore)
 		metadata, err := processes.FetchMarketplaceMetadata(applicationInstallParams.Name, applicationInstallParams.Version, &appConfig)
 		if err != nil {
 			log.Errorf("Unable to fetch metadata for application: %s, %v", applicationInstallParams.Name, err)
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "Unable to fetch package"})
+			errMsg := fmt.Sprintf("Unable to fetch package metatadata: %v", err)
+			c.JSON(http.StatusBadRequest, gin.H{"error": errMsg})
 			return
 		}
 

--- a/src/routes/install/+page.svelte
+++ b/src/routes/install/+page.svelte
@@ -75,13 +75,21 @@
     }, 5000);
   }
 
+  let errMsg = '';
   async function installApplication() {
     const outObj = { Name: product.Name, Version: product.Version, ...applicationMetadata };
     installInProgress = true;
     const url = '../api/install_application';
     const res = await fetch(url, { method: 'POST', body: JSON.stringify(outObj) });
     if (!res.ok) {
-      console.log(res);
+      try {
+        const json = await res.json();
+        if (json.error) {
+          errMsg = json.error;
+          installFailed = true;
+          installInProgress = false;
+        }
+      } catch (e) {}
       return;
     }
     startStatusPoller();
@@ -194,6 +202,9 @@
         >
       {/if}
     </div>
+    {#if errMsg}
+      <div class="st-typography-label" style="color:red;">{errMsg}</div>
+    {/if}
     {#if showLogs && logs}
       <div style="margin-top:10px">
         <hr />


### PR DESCRIPTION
Better error messaging to the MC user for some non-Terraform install error messages that have cropped up -- specifically due to missing `metatdata.json` files. Also adds a mechanism for future errors like this to be returned to the user in the UI.