### PR TITLE
updated policy to set prefix

### DIFF
--- a/backend/internal/aws/s3.go
+++ b/backend/internal/aws/s3.go
@@ -353,9 +353,10 @@ func SetBucketHealthCheckLifecyclePolicy(s3client S3BucketAPI, conf *appconfig.A
 		Expiration: &types.LifecycleExpiration{
 			Days: lifecycleInDays,
 		},
-		Filter: &types.LifecycleRuleFilterMemberPrefix{},
+		Filter: &types.LifecycleRuleFilterMemberPrefix{
+			Value: "health_check",
+		},
 		Status: types.ExpirationStatusEnabled,
-		Prefix: aws.String("health_check"),
 	}
 
 	putBucketLifecycleConfigurationInput := &s3.PutBucketLifecycleConfigurationInput{


### PR DESCRIPTION
Without specifying the prefix, the current code expires ALL objects.  Only "health_check" prefix ones should be expired.